### PR TITLE
Fix deleteCoOrganizer and resendInvitation and enable posting custom attributes to registrant creation

### DIFF
--- a/src/Resources/CoOrganizer.php
+++ b/src/Resources/CoOrganizer.php
@@ -60,7 +60,7 @@ class CoOrganizer extends AuthenticatedResourceAbstract
      *
      * @link https://developer.goto.com/GoToWebinarV2/#operation/deleteCoorganizer
      */
-    public function deleteCoOrganizer($webinarKey, $coOrganizerKey, bool $external = false): ?array
+    public function deleteCoOrganizer($webinarKey, $coOrganizerKey, bool $external = false)
     {
         $organizerKey = (new AccessTokenDecorator($this->accessToken))->getOrganizerKey();
 

--- a/src/Resources/CoOrganizer.php
+++ b/src/Resources/CoOrganizer.php
@@ -86,7 +86,7 @@ class CoOrganizer extends AuthenticatedResourceAbstract
      *
      * @link https://developer.goto.com/GoToWebinarV2/#operation/resendCoorganizerInvitation
      */
-    public function resendInvitation($webinarKey, $coOrganizerKey, bool $external = false): ?array
+    public function resendInvitation($webinarKey, $coOrganizerKey, bool $external = false)
     {
         $organizerKey = (new AccessTokenDecorator($this->accessToken))->getOrganizerKey();
 

--- a/src/Resources/Registrant.php
+++ b/src/Resources/Registrant.php
@@ -175,6 +175,9 @@ class Registrant extends \DalPraS\OAuth2\Client\Resources\AuthenticatedResourceA
     public function createRegistrant($webinarKey, $body) : array {
         $url = $this->provider->domain . '/G2W/rest/v2/organizers/' . (new AccessTokenDecorator($this->accessToken))->getOrganizerKey() . '/webinars/' . $webinarKey . '/registrants';
         $request  = $this->provider->getAuthenticatedRequest('POST', $url, $this->accessToken, [
+            'headers' => [
+                'Accept' => 'application/vnd.citrix.g2wapi-v1.1+json',
+            ],
             'body' => json_encode($body)
         ]);
         return $this->provider->getParsedResponse($request);


### PR DESCRIPTION
While testing these endpoints I noticed that even though both work, they respond with a string rather than with an array or null which in turn throws a 500 error. So removing the return type fixes the methods.