### PR TITLE
Add missing resources and ApiResponse

### DIFF
--- a/src/Loader/ResourceLoader.php
+++ b/src/Loader/ResourceLoader.php
@@ -5,24 +5,24 @@ use DalPraS\OAuth2\Client\Storage\TokenStorageInterface;
 use DalPraS\OAuth2\Client\Provider\GotoWebinar;
 
 class ResourceLoader {
-    
+
     /**
      * Token storage.
-     * 
+     *
      * @var \DalPraS\OAuth2\Client\Storage\TokenStorageInterface
      */
     private $storage;
-    
+
     /**
      * @var \DalPraS\OAuth2\Client\Provider\GotoWebinar
      */
     private $provider;
-    
+
     public function __construct(TokenStorageInterface $storage, GotoWebinar $provider) {
         $this->storage  = $storage;
         $this->provider = $provider;
     }
-    
+
     /**
      * Check if the token is valid and in case refreshes the token and
      * save it in your current storage.
@@ -34,7 +34,7 @@ class ResourceLoader {
         switch (true) {
             case $accessToken === null:
                 break;
-            
+
             case $accessToken->hasExpired():
                 $accessToken = $this->provider->getAccessToken('refresh_token', [
                     'refresh_token' => $accessToken->getRefreshToken()
@@ -45,38 +45,72 @@ class ResourceLoader {
         }
         return $accessToken;
     }
-    
+
     /**
      * Get the Webinar resource
-     * 
+     *
      * @param string $organizerKey
      * @return \DalPraS\OAuth2\Client\Resources\Webinar|NULL
      */
     public function getWebinarResource(string $organizerKey) {
         $accessToken = $this->refreshToken($this->storage->fetchToken($organizerKey));
-        return $accessToken ? (new \DalPraS\OAuth2\Client\Resources\Webinar($this->provider, $accessToken)) : null; 
+        return $accessToken ? (new \DalPraS\OAuth2\Client\Resources\Webinar($this->provider, $accessToken)) : null;
     }
-    
+
     /**
      * Get the Registrant resource
-     * 
+     *
      * @param string $organizerKey
      * @return \DalPraS\OAuth2\Client\Resources\Registrant|NULL
      */
     public function getRegistrantResource(string $organizerKey) {
         $accessToken = $this->refreshToken($this->storage->fetchToken($organizerKey));
-        return $accessToken ? (new \DalPraS\OAuth2\Client\Resources\Registrant($this->provider, $accessToken)) : null; 
+        return $accessToken ? (new \DalPraS\OAuth2\Client\Resources\Registrant($this->provider, $accessToken)) : null;
     }
-    
+
     /**
      * Get the ResourceOwner using the storage with the OrganizerKey param.
-     * 
+     *
      * @param string $organizerKey
      * @return \DalPraS\OAuth2\Client\Resources\Registrant|NULL
      */
     public function getResourceOwner(string $organizerKey) {
         $accessToken = $this->refreshToken($this->storage->fetchToken($organizerKey));
         return $accessToken ? $this->provider->getResourceOwner($accessToken) : null;
+    }
+
+    /**
+     * Get the Attenee resource
+     *
+     * @param string $organizerKey
+     * @return \DalPraS\OAuth2\Client\Resources\Attendee|NULL
+     */
+    public function getAttendeesResource(string $organizerKey)
+    {
+        $accessToken = $this->refreshToken($this->storage->fetchToken($organizerKey));
+        return $accessToken ? (new \DalPraS\OAuth2\Client\Resources\Attendee($this->provider, $accessToken)) : null;
+    }
+
+    /**
+     * Get the Attenee resource
+     *
+     * @param string $organizerKey
+     * @return \DalPraS\OAuth2\Client\Resources\Session|NULL
+     */
+    public function getSessionResource(string $organizerKey)
+    {
+        $accessToken = $this->refreshToken($this->storage->fetchToken($organizerKey));
+        return $accessToken ? (new \DalPraS\OAuth2\Client\Resources\Session($this->provider, $accessToken)) : null;
+    }
+
+    /**
+     * @param string $organizerKey
+     * @return \DalPraS\OAuth2\Client\Resources\CoOrganizer|null
+     */
+    public function getOrganizerResource(string $organizerKey)
+    {
+        $accessToken = $this->refreshToken($this->storage->fetchToken($organizerKey));
+        return $accessToken ? (new \DalPraS\OAuth2\Client\Resources\CoOrganizer($this->provider, $accessToken)) : null;
     }
 }
 

--- a/src/Resources/Attendee.php
+++ b/src/Resources/Attendee.php
@@ -3,28 +3,33 @@
 namespace DalPraS\OAuth2\Client\Resources;
 
 use DalPraS\OAuth2\Client\Decorators\AccessTokenDecorator;
+use DalPraS\OAuth2\Client\Response\ApiResponse;
+use Google\Protobuf\Api;
 
 class Attendee extends AuthenticatedResourceAbstract
 {
+    /**
+     * @param array $params
+     * @return ApiResponse|mixed
+     */
+    public function get($params = [], $path = "")
+    {
+        return new ApiResponse($this->request("get", $path, $params), '', $path, $params);
+    }
+
     /**
      * Get session attendees
      *
      * @param int|string $webinarKey
      * @param int|string $sessionKey
-     * @return array
+     * @return ApiResponse
      * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException
      *
      * @link https://developer.goto.com/GoToWebinarV2/#operation/getAttendees
      */
-    public function getSessionAttendees($webinarKey, $sessionKey): array
+    public function getSessionAttendees($webinarKey, $sessionKey): ApiResponse
     {
-        $organizerKey = (new AccessTokenDecorator($this->accessToken))->getOrganizerKey();
-
-        $url = "{$this->provider->domain}/G2W/rest/v2/organizers/{$organizerKey}/webinars/{$webinarKey}/sessions/{$sessionKey}/attendees";
-
-        $request = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-
-        return $this->provider->getParsedResponse($request);
+        return $this->get([], "/webinars/{$webinarKey}/sessions/{$sessionKey}/attendees");
     }
 
     /**
@@ -33,20 +38,14 @@ class Attendee extends AuthenticatedResourceAbstract
      * @param int|string $webinarKey
      * @param int|string $sessionKey
      * @param int|string $registrantKey
-     * @return array
+     * @return ApiResponse
      * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException
      *
      * @link https://developer.goto.com/GoToWebinarV2/#operation/getAttendee
      */
-    public function getAttendee($webinarKey, $sessionKey, $registrantKey): array
+    public function getAttendee($webinarKey, $sessionKey, $registrantKey): ApiResponse
     {
-        $organizerKey = (new AccessTokenDecorator($this->accessToken))->getOrganizerKey();
-
-        $url = "{$this->provider->domain}/G2W/rest/v2/organizers/{$organizerKey}/webinars/{$webinarKey}/sessions/{$sessionKey}/attendees/{$registrantKey}";
-
-        $request = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-
-        return $this->provider->getParsedResponse($request);
+        return $this->get([], "/webinars/{$webinarKey}/sessions/{$sessionKey}/attendees/{$registrantKey}");
     }
 
     /**
@@ -55,20 +54,14 @@ class Attendee extends AuthenticatedResourceAbstract
      * @param int|string $webinarKey
      * @param int|string $sessionKey
      * @param int|string $registrantKey
-     * @return array
+     * @return ApiResponse
      * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException
      *
      * @link https://developer.goto.com/GoToWebinarV2/#operation/getAttendeePollAnswers
      */
-    public function getAttendeePollAnswers($webinarKey, $sessionKey, $registrantKey): array
+    public function getAttendeePollAnswers($webinarKey, $sessionKey, $registrantKey): ApiResponse
     {
-        $organizerKey = (new AccessTokenDecorator($this->accessToken))->getOrganizerKey();
-
-        $url = "{$this->provider->domain}/G2W/rest/v2/organizers/{$organizerKey}/webinars/{$webinarKey}/sessions/{$sessionKey}/attendees/{$registrantKey}/polls";
-
-        $request = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-
-        return $this->provider->getParsedResponse($request);
+        return $this->get([], "/webinars/{$webinarKey}/sessions/{$sessionKey}/attendees/{$registrantKey}/polls");
     }
 
     /**
@@ -77,20 +70,14 @@ class Attendee extends AuthenticatedResourceAbstract
      * @param int|string $webinarKey
      * @param int|string $sessionKey
      * @param int|string $registrantKey
-     * @return array
+     * @return ApiResponse
      * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException
      *
      * @link https://developer.goto.com/GoToWebinarV2/#operation/getAttendeeQuestions
      */
-    public function getAttendeeQuestions($webinarKey, $sessionKey, $registrantKey): array
+    public function getAttendeeQuestions($webinarKey, $sessionKey, $registrantKey): ApiResponse
     {
-        $organizerKey = (new AccessTokenDecorator($this->accessToken))->getOrganizerKey();
-
-        $url = "{$this->provider->domain}/G2W/rest/v2/organizers/{$organizerKey}/webinars/{$webinarKey}/sessions/{$sessionKey}/attendees/{$registrantKey}/questions";
-
-        $request = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-
-        return $this->provider->getParsedResponse($request);
+        return $this->get([], "/webinars/{$webinarKey}/sessions/{$sessionKey}/attendees/{$registrantKey}/questions");
     }
 
     /**
@@ -99,19 +86,13 @@ class Attendee extends AuthenticatedResourceAbstract
      * @param int|string $webinarKey
      * @param int|string $sessionKey
      * @param int|string $registrantKey
-     * @return array
+     * @return ApiResponse
      * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException
      *
      * @link https://developer.goto.com/GoToWebinarV2/#operation/getAttendeeSurveyAnswers
      */
-    public function getAttendeeSurveyAnswers($webinarKey, $sessionKey, $registrantKey): array
+    public function getAttendeeSurveyAnswers($webinarKey, $sessionKey, $registrantKey): ApiResponse
     {
-        $organizerKey = (new AccessTokenDecorator($this->accessToken))->getOrganizerKey();
-
-        $url = "{$this->provider->domain}/G2W/rest/v2/organizers/{$organizerKey}/webinars/{$webinarKey}/sessions/{$sessionKey}/attendees/{$registrantKey}/surveys";
-
-        $request = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-
-        return $this->provider->getParsedResponse($request);
+        return $this->get([], "/webinars/{$webinarKey}/sessions/{$sessionKey}/attendees/{$registrantKey}/surveys");
     }
 }

--- a/src/Resources/AuthenticatedResourceAbstract.php
+++ b/src/Resources/AuthenticatedResourceAbstract.php
@@ -2,6 +2,7 @@
 
 namespace DalPraS\OAuth2\Client\Resources;
 
+use DalPraS\OAuth2\Client\Decorators\AccessTokenDecorator;
 use DalPraS\OAuth2\Client\Provider\GotoWebinar;
 use League\OAuth2\Client\Token\AccessToken;
 
@@ -26,6 +27,13 @@ abstract class AuthenticatedResourceAbstract {
     public function __construct(GotoWebinar $provider, AccessToken $accessToken) {
         $this->provider    = $provider;
         $this->accessToken = $accessToken;
+    }
+
+    public function request($method, $path, $params = []){
+        $url = $this->provider->domain . '/G2W/rest/v2/organizers/' . (new AccessTokenDecorator($this->accessToken))->getOrganizerKey() . $path;
+        $url .= '?' . http_build_query($params, null, '&', \PHP_QUERY_RFC3986);
+        $request  = $this->provider->getAuthenticatedRequest($method, $url, $this->accessToken);
+        return $this->provider->getParsedResponse($request);
     }
 }
 

--- a/src/Resources/CoOrganizer.php
+++ b/src/Resources/CoOrganizer.php
@@ -6,6 +6,7 @@ use DalPraS\OAuth2\Client\Decorators\AccessTokenDecorator;
 
 class CoOrganizer extends AuthenticatedResourceAbstract
 {
+
     /**
      * Get co-organizers
      *

--- a/src/Resources/Registrant.php
+++ b/src/Resources/Registrant.php
@@ -3,8 +3,19 @@
 namespace DalPraS\OAuth2\Client\Resources;
 
 use DalPraS\OAuth2\Client\Decorators\AccessTokenDecorator;
+use DalPraS\OAuth2\Client\Response\ApiResponse;
 
-class Registrant extends \DalPraS\OAuth2\Client\Resources\AuthenticatedResourceAbstract {
+class Registrant extends \DalPraS\OAuth2\Client\Resources\AuthenticatedResourceAbstract
+{
+
+    /**
+     * @param array $params
+     * @return ApiResponse|mixed
+     */
+    public function get($params = [], $path = "")
+    {
+        return new ApiResponse($this->request("get", $path, $params), '', $path, $params);
+    }
 
     /**
      * Get all registrants for a given webinar.
@@ -13,24 +24,11 @@ class Registrant extends \DalPraS\OAuth2\Client\Resources\AuthenticatedResourceA
      * @link https://developer.goto.com/GoToWebinarV2#operation/getAllRegistrantsForWebinar
      *
      * @param int $webinarKey
-     * @return array
-     * [
-     *   [
-     *     "lastName" => "string",
-     *     "email" => "string",
-     *     "firstName" => "string",
-     *     "registrantKey" => 0,
-     *     "registrationDate" => "2019-01-30T09:00:00Z",
-     *     "status" => "APPROVED",
-     *     "joinUrl" => "string",
-     *     "timeZone" => "string"
-     *   ]
-     * ]
+     * @return ApiResponse
      */
-    public function getRegistrants($webinarKey):array {
-        $url = $this->provider->domain . '/G2W/rest/v2/organizers/' . (new AccessTokenDecorator($this->accessToken))->getOrganizerKey() . '/webinars/' . $webinarKey . '/registrants';
-        $request  = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-        return $this->provider->getParsedResponse($request);
+    public function getRegistrants($webinarKey): ApiResponse
+    {
+        return $this->get([], '/webinars/' . $webinarKey . '/registrants');
     }
 
     /**
@@ -41,44 +39,12 @@ class Registrant extends \DalPraS\OAuth2\Client\Resources\AuthenticatedResourceA
      *
      * @param int $webinarKey
      * @param int $registrantKey
-     * @return array|NULL
-     * [
-     *     "firstName" => "string",
-     *     "lastName" => "string",
-     *     "email" => "string",
-     *     "registrantKey" => 0,
-     *     "registrationDate" => "2019-01-30T09:00:00Z",
-     *     "source" => "string",
-     *     "status" => "APPROVED",
-     *     "joinUrl" => "string",
-     *     "timeZone" => "string",
-     *     "phone" => "string",
-     *     "state" => "string",
-     *     "city" => "string",
-     *     "organization" => "string",
-     *     "zipCode" => "string",
-     *     "numberOfEmployees" => "string",
-     *     "industry" => "string",
-     *     "jobTitle" => "string",
-     *     "purchasingRole" => "string",
-     *     "implementationTimeFrame" => "string",
-     *     "purchasingTimeFrame" => "string",
-     *     "questionsAndComments" => "string",
-     *     "employeeCount" => "string",
-     *     "country" => "string",
-     *     "address" => "string",
-     *     "type" => "REGULAR",
-     *     "unsubscribed" => true,
-     *     "responses" => [[
-     *         "answer" => "string",
-     *         "question" => "string"
-     *     ]]
-     * ]
+     * @return ApiResponse
      */
-    public function getRegistrant($webinarKey, $registrantKey):array {
-        $url = $this->provider->domain . '/G2W/rest/v2/organizers/' . (new AccessTokenDecorator($this->accessToken))->getOrganizerKey() . '/webinars/' . $webinarKey . '/registrants/' . $registrantKey;
-        $request  = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-        return $this->provider->getParsedResponse($request);
+    public function getRegistrant($webinarKey, $registrantKey): ApiResponse
+    {
+        return $this->get([], '/webinars/' . $webinarKey . '/registrants/' . $registrantKey);
+
     }
 
     /**
@@ -122,8 +88,9 @@ class Registrant extends \DalPraS\OAuth2\Client\Resources\AuthenticatedResourceA
      *     ]]
      * ]
      */
-    public function getRegistrantByEmail($webinarKey, $email):array {
-        $registrants = $this->getRegistrants($webinarKey);
+    public function getRegistrantByEmail($webinarKey, $email): ApiResponse
+    {
+        $registrants = $this->getRegistrants($webinarKey)->getData();
         foreach ($registrants as $registrant) {
             if ($registrant['email'] === $email) {
                 return $registrant;
@@ -172,9 +139,10 @@ class Registrant extends \DalPraS\OAuth2\Client\Resources\AuthenticatedResourceA
      *   "status" => "APPROVED",
      * ]
      */
-    public function createRegistrant($webinarKey, $body) : array {
+    public function createRegistrant($webinarKey, $body): array
+    {
         $url = $this->provider->domain . '/G2W/rest/v2/organizers/' . (new AccessTokenDecorator($this->accessToken))->getOrganizerKey() . '/webinars/' . $webinarKey . '/registrants';
-        $request  = $this->provider->getAuthenticatedRequest('POST', $url, $this->accessToken, [
+        $request = $this->provider->getAuthenticatedRequest('POST', $url, $this->accessToken, [
             'headers' => [
                 'Accept' => 'application/vnd.citrix.g2wapi-v1.1+json',
             ],
@@ -193,9 +161,10 @@ class Registrant extends \DalPraS\OAuth2\Client\Resources\AuthenticatedResourceA
      * @param int $registrantKey
      * @return array
      */
-    public function deleteRegistrant($webinarKey, $registrantKey) {
+    public function deleteRegistrant($webinarKey, $registrantKey)
+    {
         $url = $this->provider->domain . '/G2W/rest/v2/organizers/' . (new AccessTokenDecorator($this->accessToken))->getOrganizerKey() . '/webinars/' . $webinarKey . '/registrants/' . $registrantKey;
-        $request  = $this->provider->getAuthenticatedRequest('DELETE', $url, $this->accessToken);
+        $request = $this->provider->getAuthenticatedRequest('DELETE', $url, $this->accessToken);
         return $this->provider->getParsedResponse($request);
     }
 

--- a/src/Resources/Session.php
+++ b/src/Resources/Session.php
@@ -2,23 +2,33 @@
 
 namespace DalPraS\OAuth2\Client\Resources;
 
-use DalPraS\OAuth2\Client\Decorators\AccessTokenDecorator;
+use DalPraS\OAuth2\Client\Response\ApiResponse;
 
 class Session extends AuthenticatedResourceAbstract
 {
+    /**
+     * @param array $params
+     * @return ApiResponse|mixed
+     */
+    public function get($params = [], $path = "/sessions")
+    {
+        return new ApiResponse($this->request("get", $path, $params), 'sessionInfoResources', $path, $params);
+    }
+
+
     /**
      * Get organizer sessions
      *
      * @param \DateTime|null $from
      * @param \DateTime|null $to
-     * @param int|null       $page
-     * @param int|null       $size
-     * @return array
+     * @param int|null $page
+     * @param int|null $size
+     * @return ApiResponse
      * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException
      *
      * @link https://developer.goto.com/GoToWebinarV2/#operation/getOrganizerSessions
      */
-    public function getSessions(?\DateTime $from = null, ?\DateTime $to = null, ?int $page = null, ?int $size = null): array
+    public function getSessions(?\DateTime $from = null, ?\DateTime $to = null, ?int $page = null, ?int $size = null): ApiResponse
     {
         $utcTimeZone = new \DateTimeZone('UTC');
 
@@ -26,49 +36,36 @@ class Session extends AuthenticatedResourceAbstract
             'fromTime' => $from
                 ? $from->setTimezone($utcTimeZone)->format('Y-m-d\TH:i:s\Z')
                 : (new \DateTime('-3 years', $utcTimeZone))->format('Y-m-d\TH:i:s\Z'),
-            'toTime'   => $to
+            'toTime' => $to
                 ? $to->setTimezone($utcTimeZone)->format('Y-m-d\TH:i:s\Z')
                 : (new \DateTime('-3 years', $utcTimeZone))->format('Y-m-d\TH:i:s\Z'),
-            'page'     => $page && $page > -1 ? $page : 0,
-            'size'     => $size && $size > 0 ? $size : 100
+            'page' => $page && $page > -1 ? $page : 0,
+            'size' => $size && $size > 0 ? $size : 100
         ];
 
-        $organizerKey = (new AccessTokenDecorator($this->accessToken))->getOrganizerKey();
 
-        $url = "{$this->provider->domain}/G2W/rest/v2/organizers/{$organizerKey}/sessions?";
-        $url .= http_build_query($body, null, '&', \PHP_QUERY_RFC3986);
-
-        $request = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-
-        return $this->provider->getParsedResponse($request)['_embedded']['sessionInfoResources'];
+        return $this->get($body);
     }
 
     /**
      * Get webinar sessions
      *
      * @param int|string $webinarKey
-     * @param int|null   $page
-     * @param int|null   $size
-     * @return array
+     * @param int|null $page
+     * @param int|null $size
+     * @return ApiResponse
      * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException
      *
      * @link https://developer.goto.com/GoToWebinarV2/#operation/getAllSessions
      */
-    public function getWebinarSessions($webinarKey, ?int $page = null, ?int $size = null): array
+    public function getWebinarSessions($webinarKey, ?int $page = null, ?int $size = null): ApiResponse
     {
         $body = [
             'page' => $page && $page > -1 ? $page : 0,
             'size' => $size && $size > 0 ? $size : 100
         ];
 
-        $organizerKey = (new AccessTokenDecorator($this->accessToken))->getOrganizerKey();
-
-        $url = "{$this->provider->domain}/G2W/rest/v2/organizers/{$organizerKey}/webinars/{$webinarKey}/sessions?";
-        $url .= http_build_query($body, null, '&', \PHP_QUERY_RFC3986);
-
-        $request = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-
-        return $this->provider->getParsedResponse($request)['_embedded']['sessionInfoResources'];
+        return $this->get($body, "/webinars/{$webinarKey}/sessions");
     }
 
     /**
@@ -81,15 +78,9 @@ class Session extends AuthenticatedResourceAbstract
      *
      * @link https://developer.goto.com/GoToWebinarV2/#operation/getWebinarSession
      */
-    public function getWebinarSession($webinarKey, $sessionKey): array
+    public function getWebinarSession($webinarKey, $sessionKey): ApiResponse
     {
-        $organizerKey = (new AccessTokenDecorator($this->accessToken))->getOrganizerKey();
-
-        $url = "{$this->provider->domain}/G2W/rest/v2/organizers/{$organizerKey}/webinars/{$webinarKey}/sessions/{$sessionKey}";
-
-        $request = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-
-        return $this->provider->getParsedResponse($request);
+        return $this->get([], "/webinars/{$webinarKey}/sessions/{$sessionKey}");
     }
 
     /**
@@ -102,15 +93,9 @@ class Session extends AuthenticatedResourceAbstract
      *
      * @link https://developer.goto.com/GoToWebinarV2/#operation/getPerformance
      */
-    public function getSessionPerformance($webinarKey, $sessionKey): array
+    public function getSessionPerformance($webinarKey, $sessionKey): ApiResponse
     {
-        $organizerKey = (new AccessTokenDecorator($this->accessToken))->getOrganizerKey();
-
-        $url = "{$this->provider->domain}/G2W/rest/v2/organizers/{$organizerKey}/webinars/{$webinarKey}/sessions/{$sessionKey}/performance";
-
-        $request = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-
-        return $this->provider->getParsedResponse($request);
+        return $this->get([], "/webinars/{$webinarKey}/sessions/{$sessionKey}/performance");
     }
 
     /**
@@ -123,15 +108,9 @@ class Session extends AuthenticatedResourceAbstract
      *
      * @link https://developer.goto.com/GoToWebinarV2/#operation/getPolls
      */
-    public function getSessionPolls($webinarKey, $sessionKey): array
+    public function getSessionPolls($webinarKey, $sessionKey): ApiResponse
     {
-        $organizerKey = (new AccessTokenDecorator($this->accessToken))->getOrganizerKey();
-
-        $url = "{$this->provider->domain}/G2W/rest/v2/organizers/{$organizerKey}/webinars/{$webinarKey}/sessions/{$sessionKey}/polls";
-
-        $request = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-
-        return $this->provider->getParsedResponse($request);
+        return $this->get([], "/webinars/{$webinarKey}/sessions/{$sessionKey}/polls");
     }
 
     /**
@@ -144,15 +123,9 @@ class Session extends AuthenticatedResourceAbstract
      *
      * @link https://developer.goto.com/GoToWebinarV2/#operation/getQuestions
      */
-    public function getSessionQuestions($webinarKey, $sessionKey): array
+    public function getSessionQuestions($webinarKey, $sessionKey): ApiResponse
     {
-        $organizerKey = (new AccessTokenDecorator($this->accessToken))->getOrganizerKey();
-
-        $url = "{$this->provider->domain}/G2W/rest/v2/organizers/{$organizerKey}/webinars/{$webinarKey}/sessions/{$sessionKey}/questions";
-
-        $request = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-
-        return $this->provider->getParsedResponse($request);
+        return $this->get([], "/webinars/{$webinarKey}/sessions/{$sessionKey}/questions");
     }
 
     /**
@@ -165,14 +138,8 @@ class Session extends AuthenticatedResourceAbstract
      *
      * @link https://developer.goto.com/GoToWebinarV2/#operation/getSurveys
      */
-    public function getSessionSurveys($webinarKey, $sessionKey): array
+    public function getSessionSurveys($webinarKey, $sessionKey): ApiResponse
     {
-        $organizerKey = (new AccessTokenDecorator($this->accessToken))->getOrganizerKey();
-
-        $url = "{$this->provider->domain}/G2W/rest/v2/organizers/{$organizerKey}/webinars/{$webinarKey}/sessions/{$sessionKey}/surveys";
-
-        $request = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-
-        return $this->provider->getParsedResponse($request);
+        return $this->get([], "/webinars/{$webinarKey}/sessions/{$sessionKey}/surveys");
     }
 }

--- a/src/Resources/Webinar.php
+++ b/src/Resources/Webinar.php
@@ -3,53 +3,42 @@
 namespace DalPraS\OAuth2\Client\Resources;
 
 use DalPraS\OAuth2\Client\Decorators\AccessTokenDecorator;
+use DalPraS\OAuth2\Client\Response\ApiResponse;
 
-class Webinar extends \DalPraS\OAuth2\Client\Resources\AuthenticatedResourceAbstract {
+class Webinar extends \DalPraS\OAuth2\Client\Resources\AuthenticatedResourceAbstract
+{
+
+    /**
+     * @param array $params
+     * @return ApiResponse|mixed
+     */
+    public function get($params = [])
+    {
+        $path = '/webinars';
+        return new ApiResponse($this->request('GET', $path, $params), 'webinars', $path, $params);
+    }
 
     /**
      * Get all webinars.
      *
      * https://api.getgo.com/G2W/rest/v2/account/{accountKey}/webinars?page=0&size=20
-     * 
+     *
      * @link https://developer.goto.com/GoToWebinarV2/#operation/getWebinars
      *
      * @return array
-     * [
-     *    [
-     *       "webinarKey" => "string",
-     *       "webinarID" => "string",
-     *       "organizerKey" => "string",
-     *       "accountKey" => "string",
-     *       "subject" => "string",
-     *       "description" => "string",
-     *       "times" => [[
-     *           "startTime" => "2019-01-30T15:00:00Z",
-     *           "endTime" => "2019-01-30T16:00:00Z"
-     *       ]],
-     *       "timeZone" => "string",
-     *       "locale" => "en_US",
-     *       "approvalType" => "string",
-     *       "registrationUrl" => "string",
-     *       "impromptu" => true,
-     *       "isPasswordProtected" => true,
-     *       "recurrenceType" => "string",
-     *       "experienceType" => "string"
-     *    ]
-     * ]
+     * @return ApiResponse|mixed
      */
-    public function getWebinars():array {
+    public function getWebinars(): ApiResponse
+    {
         $utcTimeZone = new \DateTimeZone('UTC');
-        $body      = [
+        $params = [
             'fromTime' => (new \DateTime('-3 years', $utcTimeZone))->format('Y-m-d\TH:i:s\Z'),
-            'toTime'   => (new \DateTime('+3 years', $utcTimeZone))->format('Y-m-d\TH:i:s\Z'),
-            'page'     => 0,
-            'size'     => 100
+            'toTime' => (new \DateTime('+3 years', $utcTimeZone))->format('Y-m-d\TH:i:s\Z'),
+            'page' => 0,
+            'size' => 100
         ];
 
-        $url = $this->provider->domain . '/G2W/rest/v2/organizers/' . (new AccessTokenDecorator($this->accessToken))->getOrganizerKey() . '/webinars';
-        $url .= '?' . http_build_query($body, null, '&', \PHP_QUERY_RFC3986);
-        $request  = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-        return $this->provider->getParsedResponse($request)['_embedded']['webinars'];
+        return $this->get($params);
     }
 
 
@@ -57,45 +46,22 @@ class Webinar extends \DalPraS\OAuth2\Client\Resources\AuthenticatedResourceAbst
      * Get upcoming webinars.
      *
      * https://api.getgo.com/G2W/rest/v2/account/{accountKey}/webinars?page=0&size=20
-     * 
+     *
      * @link https://developer.goto.com/GoToWebinarV2/#operation/getWebinars
      *
      * @return array
-     * [
-     *    [
-     *       "webinarKey" => "string",
-     *       "webinarID" => "string",
-     *       "organizerKey" => "string",
-     *       "accountKey" => "string",
-     *       "subject" => "string",
-     *       "description" => "string",
-     *       "times" => [[
-     *           "startTime" => "2019-01-30T15:00:00Z",
-     *           "endTime" => "2019-01-30T16:00:00Z"
-     *       ]],
-     *       "timeZone" => "string",
-     *       "locale" => "en_US",
-     *       "approvalType" => "string",
-     *       "registrationUrl" => "string",
-     *       "impromptu" => true,
-     *       "isPasswordProtected" => true,
-     *       "recurrenceType" => "string",
-     *       "experienceType" => "string"
-     *    ]
-     * ]
+     * @return ApiResponse|mixed
      */
-    public function getUpcoming():array {
+    public function getUpcoming(): ApiResponse
+    {
         $utcTimeZone = new \DateTimeZone('UTC');
-        $body      = [
+        $params = [
             'fromTime' => (new \DateTime('now', $utcTimeZone))->format('Y-m-d\TH:i:s\Z'),
-            'toTime'   => (new \DateTime('+3 year', $utcTimeZone))->format('Y-m-d\TH:i:s\Z'),
-            'page'     => 0,
-            'size'     => 100
+            'toTime' => (new \DateTime('+3 year', $utcTimeZone))->format('Y-m-d\TH:i:s\Z'),
+            'page' => 0,
+            'size' => 100
         ];
-        $url = $this->provider->domain . '/G2W/rest/v2/organizers/' . (new AccessTokenDecorator($this->accessToken))->getOrganizerKey() . '/webinars';
-        $url .= '?' . http_build_query($body, null, '&', \PHP_QUERY_RFC3986);
-        $request  = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-        return $this->provider->getParsedResponse($request)['_embedded']['webinars'];
+        return $this->get($params);
     }
 
 
@@ -109,92 +75,45 @@ class Webinar extends \DalPraS\OAuth2\Client\Resources\AuthenticatedResourceAbst
      * @param \DateTime $startDate
      * @param \DateTime $endDate
      * @return array
-     * [
-     *    [
-     *       "webinarKey" => "string",
-     *       "webinarID" => "string",
-     *       "organizerKey" => "string",
-     *       "accountKey" => "string",
-     *       "subject" => "string",
-     *       "description" => "string",
-     *       "times" => [[
-     *           "startTime" => "2019-01-30T15:00:00Z",
-     *           "endTime" => "2019-01-30T16:00:00Z"
-     *       ]],
-     *       "timeZone" => "string",
-     *       "locale" => "en_US",
-     *       "approvalType" => "string",
-     *       "registrationUrl" => "string",
-     *       "impromptu" => true,
-     *       "isPasswordProtected" => true,
-     *       "recurrenceType" => "string",
-     *       "experienceType" => "string"
-     *    ]
-     * ]
+     *
+     * @return array
+     * @return ApiResponse|mixed
      */
-    public function getPast($startDate, $endDate = null):array {
+    public function getPast($startDate, $endDate = null): ApiResponse
+    {
         $utcTimeZone = new \DateTimeZone('UTC');
         if ($endDate === null) {
             $endDate = new \DateTime('now', $utcTimeZone);
         }
-        $body      = [
+        $params = [
             'fromTime' => $startDate->setTimezone($utcTimeZone)->format('Y-m-d\TH:i:s\Z'),
-            'toTime'   => $endDate->format('Y-m-d\TH:i:s\Z'),
-            'page'     => 0,
-            'size'     => 100
+            'toTime' => $endDate->format('Y-m-d\TH:i:s\Z'),
+            'page' => 0,
+            'size' => 100
         ];
-        $url         = $this->provider->domain . '/G2W/rest/v2/organizers/' . (new AccessTokenDecorator($this->accessToken))->getOrganizerKey() . '/webinars';
-        $url .= '?' . http_build_query($body, null, '&', \PHP_QUERY_RFC3986);
-        $request  = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-        return $this->provider->getParsedResponse($request)['_embedded']['webinars'];
+        return $this->get($params);
     }
 
     /**
      * Get info for a single webinar by passing the webinar id or
      * in GotoWebinar's terms webinarKey.
-     * 
+     *
      * @link https://developer.goto.com/GoToWebinarV2#operation/getWebinar
      *
      * @param int $webinarKey
-     * @return array
-     * [
-     *   "webinarKey" => 0,
-     *   "webinarID" => "string",
-     *   "subject" => "string",
-     *   "description" => "string",
-     *   "organizerKey" => 0,
-     *   "organizerEmail" => "string",
-     *   "organizerName" => "string",
-     *   "times" => [[
-     *       "startTime" => "2019-01-30T15:00:00Z",
-     *       "endTime" => "2019-01-30T16:00:00Z"
-     *   ]],
-     *   "registrationUrl" => "string",
-     *   "inSession" => true,
-     *   "impromptu" => true,
-     *   "type" => "string",
-     *   "timeZone" => "string",
-     *   "numberOfRegistrants" => 0,
-     *   "registrationLimit" => 0,
-     *   "locale" => "en_US",
-     *   "accountKey" => "string",
-     *   "recurrencePeriod" => "string",
-     *   "experienceType" => "string",
-     *   "isPasswordProtected" => true
-     * ]
+     * @return ApiResponse|mixed
      */
-    public function getWebinar($webinarKey):array {
-        $url = $this->provider->domain . '/G2W/rest/v2/organizers/' . (new AccessTokenDecorator($this->accessToken))->getOrganizerKey() . '/webinars/' . $webinarKey;
-        $request  = $this->provider->getAuthenticatedRequest('GET', $url, $this->accessToken);
-        return $this->provider->getParsedResponse($request);
+    public function getWebinar($webinarKey): ApiResponse
+    {
+        return new ApiResponse($this->request("get", '/webinars/' . $webinarKey));
     }
 
     /**
      * Create a new webinar.
      * Return the the WebinarKey.
-     * 
+     *
      * @link https://developer.goto.com/GoToWebinarV2#operation/createWebinar
-     * 
+     *
      * @param array $body
      * [
      *      "subject" => "subject",
@@ -216,9 +135,10 @@ class Webinar extends \DalPraS\OAuth2\Client\Resources\AuthenticatedResourceAbst
      *   "webinarKey": "string"
      * ]
      */
-    public function createWebinar(array $body = []) : array {
+    public function createWebinar(array $body = []): array
+    {
         $url = $this->provider->domain . '/G2W/rest/v2/organizers/' . (new AccessTokenDecorator($this->accessToken))->getOrganizerKey() . '/webinars';
-        $request  = $this->provider->getAuthenticatedRequest('POST', $url, $this->accessToken, [
+        $request = $this->provider->getAuthenticatedRequest('POST', $url, $this->accessToken, [
             'body' => json_encode($body)
         ]);
         return $this->provider->getParsedResponse($request);
@@ -244,9 +164,10 @@ class Webinar extends \DalPraS\OAuth2\Client\Resources\AuthenticatedResourceAbst
      *
      * @return array
      */
-    public function updateWebinar($webinarKey, array $body = []) {
+    public function updateWebinar($webinarKey, array $body = [])
+    {
         $url = $this->provider->domain . '/G2W/rest/v2/organizers/' . (new AccessTokenDecorator($this->accessToken))->getOrganizerKey() . '/webinars/' . $webinarKey;
-        $request  = $this->provider->getAuthenticatedRequest('PUT', $url, $this->accessToken, [
+        $request = $this->provider->getAuthenticatedRequest('PUT', $url, $this->accessToken, [
             'body' => json_encode($body)
         ]);
         return $this->provider->getParsedResponse($request);
@@ -255,16 +176,17 @@ class Webinar extends \DalPraS\OAuth2\Client\Resources\AuthenticatedResourceAbst
     /**
      * Delete a webinar.
      * https://api.getgo.com/G2W/rest/v2/organizers/{organizerKey}/webinars/{webinarKey}?sendCancellationEmails=false
-     * 
+     *
      * @link https://developer.goto.com/GoToWebinarV2#operation/cancelWebinar
      *
      * @param string $webinarKey
      * @return void
      */
-    public function deleteWebinar($webinarKey, $sendCancellationEmails = false) {
+    public function deleteWebinar($webinarKey, $sendCancellationEmails = false)
+    {
         $url = $this->provider->domain . '/G2W/rest/v2/organizers/' . (new AccessTokenDecorator($this->accessToken))->getOrganizerKey() . '/webinars/' . $webinarKey;
         $url .= '?' . http_build_query(['sendCancellationEmails' => $sendCancellationEmails], null, '&', PHP_QUERY_RFC3986);
-        $request  = $this->provider->getAuthenticatedRequest('DELETE', $url, $this->accessToken);
+        $request = $this->provider->getAuthenticatedRequest('DELETE', $url, $this->accessToken);
         return $this->provider->getParsedResponse($request);
     }
 

--- a/src/Response/ApiResponse.php
+++ b/src/Response/ApiResponse.php
@@ -1,0 +1,48 @@
+<?php
+namespace DalPraS\OAuth2\Client\Response;
+
+use Doctrine\DBAL\Types\ObjectType;
+
+/**
+ * Class ApiResponse
+ * @package DalPraS\OAuth2\Client\Response
+ */
+class ApiResponse
+{
+
+    public $response;
+    protected $type;
+    protected $path;
+    protected $args;
+
+    public function __construct($response, $type = "", $path = "", $args = "")
+    {
+        $this->response = $response;
+        $this->type = $type;
+        $this->path = $path;
+        $this->args = $args;
+    }
+
+    public function getData(){
+        // Non paged response
+        if (isset($this->response['response'])) {
+            return $this->response['response'];
+        }
+
+        if (!isset($this->response['page'])) {
+            return $this->response;
+        }
+
+        // Paged response
+        if (isset($this->response['_embedded'])) {
+            return $this->response['_embedded'][$this->type];
+        }
+
+        // Empty paged response
+        return [];
+    }
+
+    public function getPaging(){
+        return $this->response['page'];
+    }
+}


### PR DESCRIPTION
1. Adds, all missing resource to ResourceLoader

2. Changes how the response is handled. **This is a breaking change.** 
The original code would throw an exception if a paged response had no results. 
The original code would not give you access to the part of the response related to paging. 

Now, all response is returned as an ApiResponse, which address the above issues.
```php
$response = $client->registrants()->getRegistrants($webinarKey);     
$registrants = $response->getData();  // returns array of registrants or [] if no registrants were found
$paging = $response->getPaging(); // returns paging information
```
